### PR TITLE
Perform deep checkout on forks

### DIFF
--- a/.github/workflows/linter-caller.yml
+++ b/.github/workflows/linter-caller.yml
@@ -7,6 +7,11 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+  packages: read
+  statuses: write
+
 jobs:
   lint:
     name: Lint code base

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -43,15 +43,8 @@ jobs:
   lint:
     name: Lint code base
     runs-on: ubuntu-22.04
-    # env:
-    #   FETCH_DEPTH: 1
 
     steps:
-    #   - name: Override fetch depth for PRs from forks
-    #     if: github.event.pull_request.head.repo.fork
-    #     run: |
-    #       echo FETCH_DEPTH=0 >> "$GITHUB_ENV"
-
       - name: Check out repository
         uses: actions/checkout@v4.1.1
         with:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -41,21 +41,19 @@ jobs:
   lint:
     name: Lint code base
     runs-on: ubuntu-22.04
+    env:
+      FETCH_DEPTH: 1
 
     steps:
-      - name: Dump payload
-        env:
-          fork: ${{ github.event.pull_request.head.repo.fork }}
+      - name: Override fetch depth for PRs from forks
+        if: github.event.pull_request.head.repo.fork
         run: |
-          jq -C . "$GITHUB_EVENT_PATH"
-
-          echo "$fork"
+          echo FETCH_DEPTH=0 >> "$GITHUB_ENV"
 
       - name: Check out repository
         uses: actions/checkout@v4.1.1
         with:
-          fetch-depth: >-
-            ${{ github.event.pull_request.head.repo.fork == true && 0 || 1 }}
+          fetch-depth: ${{ env.FETCH_DEPTH }}
           show-progress: false
 
       - name: Fetch default style files

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4.1.1
         with:
+          fetch-depth: ${{ github.event.pull_request.head.repo.fork && 0 || 1 }}
           show-progress: false
 
       - name: Fetch default style files

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -34,7 +34,9 @@ on:
         default:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.job }}-${{ github.head_ref }}
+  group: >-
+    ${{ format('{0}-{1}-{2}',
+      github.workflow, github.job, github.head_ref || github.sha) }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           fetch-depth: >-
-            ${{ github.event.pull_request.head.repo.fork && 0 || 1 }}
+            ${{ github.event.pull_request.head.repo.fork && '0' || 1 }}
           show-progress: false
 
       - name: Fetch default style files

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -41,19 +41,19 @@ jobs:
   lint:
     name: Lint code base
     runs-on: ubuntu-22.04
-    env:
-      FETCH_DEPTH: 1
+    # env:
+    #   FETCH_DEPTH: 1
 
     steps:
-      - name: Override fetch depth for PRs from forks
-        if: github.event.pull_request.head.repo.fork
-        run: |
-          echo FETCH_DEPTH=0 >> "$GITHUB_ENV"
+    #   - name: Override fetch depth for PRs from forks
+    #     if: github.event.pull_request.head.repo.fork
+    #     run: |
+    #       echo FETCH_DEPTH=0 >> "$GITHUB_ENV"
 
       - name: Check out repository
         uses: actions/checkout@v4.1.1
         with:
-          fetch-depth: ${{ env.FETCH_DEPTH }}
+          fetch-depth: ${{ github.event.pull_request.head.repo.fork && 0 || 1 }}
           show-progress: false
 
       - name: Fetch default style files

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -50,7 +50,8 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4.1.1
         with:
-          fetch-depth: ${{ github.event.pull_request.head.repo.fork && 0 || 1 }}
+          fetch-depth: >-
+            ${{ github.event.pull_request.head.repo.fork == true && 0 || 1 }}
           show-progress: false
 
       - name: Fetch default style files

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -44,8 +44,12 @@ jobs:
 
     steps:
       - name: Dump payload
+        env:
+          fork: ${{ github.event.pull_request.head.repo.fork }}
         run: |
           jq -C . "$GITHUB_EVENT_PATH"
+
+          echo "$fork"
 
       - name: Check out repository
         uses: actions/checkout@v4.1.1

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -43,6 +43,10 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
+      - name: Dump payload
+        run: |
+          jq -C . "$GITHUB_EVENT_PATH"
+
       - name: Check out repository
         uses: actions/checkout@v4.1.1
         with:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           fetch-depth: >-
-            ${{ github.event.pull_request.head.repo.fork == true && 0 || 1 }}
+            ${{ github.event.pull_request.head.repo.fork && 0 || 1 }}
           show-progress: false
 
       - name: Fetch default style files

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -53,7 +53,8 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4.1.1
         with:
-          fetch-depth: ${{ github.event.pull_request.head.repo.fork && 0 || 1 }}
+          fetch-depth: >-
+            ${{ github.event.pull_request.head.repo.fork == true && 0 || 1 }}
           show-progress: false
 
       - name: Fetch default style files

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           fetch-depth: >-
-            ${{ github.event.pull_request.head.repo.fork == 'true' && 0 || 1 }}
+            ${{ github.event.pull_request.head.repo.fork == true && 0 || 1 }}
           show-progress: false
 
       - name: Fetch default style files

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           fetch-depth: >-
-            ${{ github.event.pull_request.head.repo.fork == true && 0 || 1 }}
+            ${{ github.event.pull_request.head.repo.fork == 'true' && 0 || 1 }}
           show-progress: false
 
       - name: Fetch default style files

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+<benjamin.wuethrich@gmail.com> <8521043+bewuethr@users.noreply.github.com>


### PR DESCRIPTION
When the linter workflow is triggered from a PR on a fork, don't do a shallow clone, but a deep one.

Additional changes:

- Update the concurrency group: `github.head_ref` exists only for pull requests. For other triggers, use the commit SHA instead.
- Add explicit permissions to the linter caller, after changing the default permissions for this repo.
- Add a mailmap.